### PR TITLE
refactor: switch argparsing to clap-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,24 @@ checksum = "3b1a0a4208c6c483b952ad35c6eed505fc13b46f08f631b81e828084a9318d74"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
+ "once_cell",
  "strsim",
  "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -90,6 +105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,10 +132,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -214,6 +265,12 @@ name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ description = "Super powered GNU Stow replacement"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "4.0.7"
+clap = { version = "4.0", features = ["derive"] }
 colored = "2.0.0"
 dirs = "4.0.0"

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -93,7 +93,7 @@ fn run_hook(program: &str, hook_type: DeployStep) {
     }
 }
 
-pub fn set_cmd(programs: clap::parser::ValuesRef<String>) {
+pub fn set_cmd(programs: &[String]) {
     let run_deploy_steps = |step: DeployStages, program: &str| {
         for i in step {
             match i {
@@ -101,7 +101,7 @@ pub fn set_cmd(programs: clap::parser::ValuesRef<String>) {
                     run_hook(program, DeployStep::PreHook);
                 }
 
-                DeployStep::Symlink => symlinks::add_cmd(programs.clone()),
+                DeployStep::Symlink => symlinks::add_cmd(programs),
 
                 DeployStep::PostHook => {
                     run_hook(program, DeployStep::PostHook);
@@ -111,7 +111,7 @@ pub fn set_cmd(programs: clap::parser::ValuesRef<String>) {
         }
     };
 
-    for program in programs.clone() {
+    for program in programs {
         if program == "*" {
             let dir = fs::read_dir(fileops::get_dotfiles_path().unwrap() + "/Hooks").unwrap();
             for folder in dir {

--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -126,7 +126,7 @@ impl SymlinkHandler {
     }
 }
 
-pub fn add_cmd(programs: clap::parser::ValuesRef<String>) {
+pub fn add_cmd(programs: &[String]) {
     let sym = SymlinkHandler::new();
     for program in programs {
         // add all programs if wildcard
@@ -143,7 +143,7 @@ pub fn add_cmd(programs: clap::parser::ValuesRef<String>) {
     }
 }
 
-pub fn remove_cmd(programs: clap::parser::ValuesRef<String>) {
+pub fn remove_cmd(programs: &[String]) {
     let sym = SymlinkHandler::new();
     for program in programs {
         // remove all programs if wildcard


### PR DESCRIPTION
Hi, nice to see an opinionated stow replacement out there! 😄

This switches the Builder API to the Derive API, to hopefully cut down on some boilerplate code.

I also took the liberty to adjust some help descriptions, and made the `PROGRAM` args required so that clap protests if none are specified.