### PR TITLE
a few tiny fixes to satisfy the rust-analyzer

### DIFF
--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -132,7 +132,7 @@ pub fn init_cmd() -> Result<(), ExitCode> {
 
 pub fn push_cmd(group: String, files: &[String]) -> Result<(), ExitCode> {
     let dotfiles_dir = match dotfiles::get_dotfiles_path() {
-        Ok(dir) => dir.join("Configs").join(&group),
+        Ok(dir) => dir.join("Configs").join(group),
         Err(e) => {
             eprintln!("{e}");
             return Err(ReturnCode::CouldntFindDotfiles.into());

--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -743,11 +743,11 @@ mod tests {
             fs::create_dir_all(&new_config_dir).unwrap();
 
             let mut file = File::create(new_config_dir.join("group_file")).unwrap();
-            file.write("Some random content on file".as_bytes())
+            let _ =file.write("Some random content on file".as_bytes())
                 .unwrap();
 
             let mut file2 = File::create(group_dir.join("group_file_0")).unwrap();
-            file2
+            let _ = file2
                 .write("Some random content on file".as_bytes())
                 .unwrap();
             Self


### PR DESCRIPTION
  
Explicitly show that we do not care about written amount of bytes with
  'let _ = '
  Pass just a string not a ref