### PR TITLE
Filter conditional groups in wildcard matching

### DIFF
--- a/src/dotfiles.rs
+++ b/src/dotfiles.rs
@@ -144,28 +144,28 @@ pub fn group_ends_with_target_name(group: &str) -> bool {
     VALID_TARGETS.iter().any(|target| group.ends_with(target))
 }
 
-impl Dotfile {
-    /// Returns true if a group with specified name can be used by current platform.
-    /// Checks if a group should be linked on current platform. For unconditional
-    /// groups, this function returns true; for conditional groups, this function
-    /// returns true when group suffix matches current target_os or target_family.
-    pub fn group_is_valid_target(group: &str) -> bool {
-        // Gets the current OS and OS family
-        let current_target_os = format!("_{}", env::consts::OS);
-        let current_target_family = format!("_{}", env::consts::FAMILY);
+/// Returns true if a group with specified name can be used by current platform.
+/// Checks if a group should be linked on current platform. For unconditional
+/// groups, this function returns true; for conditional groups, this function
+/// returns true when group suffix matches current target_os or target_family.
+pub fn group_is_valid_target(group: &str) -> bool {
+    // Gets the current OS and OS family
+    let current_target_os = format!("_{}", env::consts::OS);
+    let current_target_family = format!("_{}", env::consts::FAMILY);
 
-        // returns true if a group has no suffix or its suffix matches the current OS
-        if group_ends_with_target_name(group) {
-            group.ends_with(&current_target_os) || group.ends_with(&current_target_family)
-        } else {
-            true
-        }
+    // returns true if a group has no suffix or its suffix matches the current OS
+    if group_ends_with_target_name(group) {
+        group.ends_with(&current_target_os) || group.ends_with(&current_target_family)
+    } else {
+        true
     }
+}
 
+impl Dotfile {
     /// Returns true if the target can be used by the current platform
     pub fn is_valid_target(&self) -> bool {
         let group = self.group_name.as_str();
-        Self::group_is_valid_target(group)
+        group_is_valid_target(group)
     }
 
     /// Checks whether the current groups is targetting the root path aka `/`

--- a/src/dotfiles.rs
+++ b/src/dotfiles.rs
@@ -145,20 +145,27 @@ pub fn group_ends_with_target_name(group: &str) -> bool {
 }
 
 impl Dotfile {
-    /// Returns true if the target can be used by the current platform
-    pub fn is_valid_target(&self) -> bool {
+    /// Returns true if a group with specified name can be used by current platform.
+    /// Checks if a group should be linked on current platform. For unconditional
+    /// groups, this function returns true; for conditional groups, this function
+    /// returns true when group suffix matches current target_os or target_family.
+    pub fn group_is_valid_target(group: &str) -> bool {
         // Gets the current OS and OS family
         let current_target_os = format!("_{}", env::consts::OS);
         let current_target_family = format!("_{}", env::consts::FAMILY);
 
         // returns true if a group has no suffix or its suffix matches the current OS
-        let group = self.group_name.as_str();
-
         if group_ends_with_target_name(group) {
             group.ends_with(&current_target_os) || group.ends_with(&current_target_family)
         } else {
             true
         }
+    }
+
+    /// Returns true if the target can be used by the current platform
+    pub fn is_valid_target(&self) -> bool {
+        let group = self.group_name.as_str();
+        Self::group_is_valid_target(group)
     }
 
     /// Checks whether the current groups is targetting the root path aka `/`

--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -354,6 +354,14 @@ fn foreach_group<F: Fn(&SymlinkHandler, &String)>(
             if exclude.contains(group) {
                 continue;
             }
+
+            // Ignore conditional groups in wildcard matching.
+            // To force linking group of other target_os/target_family, use
+            // explict argument passing.
+            if dotfiles::group_ends_with_target_name(&group) {
+                continue;
+            }
+
             // do something with the group name
             // passing the sym context
             func(&sym, group);

--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -355,10 +355,10 @@ fn foreach_group<F: Fn(&SymlinkHandler, &String)>(
                 continue;
             }
 
-            // Ignore conditional groups in wildcard matching.
-            // To force linking group of other target_os/target_family, use
-            // explict argument passing.
-            if dotfiles::group_ends_with_target_name(&group) {
+            // Ignore conditional groups for other platforms.
+            // To force linking a group of other target_os/target_family, use
+            // explict argument passing instead of wildcard.
+            if !Dotfile::group_is_valid_target(&group) {
                 continue;
             }
 

--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -358,7 +358,7 @@ fn foreach_group<F: Fn(&SymlinkHandler, &String)>(
             // Ignore conditional groups for other platforms.
             // To force linking a group of other target_os/target_family, use
             // explict argument passing instead of wildcard.
-            if !Dotfile::group_is_valid_target(&group) {
+            if !dotfiles::group_is_valid_target(&group) {
                 continue;
             }
 


### PR DESCRIPTION
This pull request fixes issue #38.

All conditional groups for platforms other than current platform will be ignored in wildcard matching, but link operation for that specific group is still available via explicit argument passing.

e.g. `tuckr add '*'` will ignore `clangd_windows` on Linux, and behavior of `tuckr add clangd_windows` is unchanged, which will force `clangd_windows` to be linked.