### PR TITLE
Add assume_yes option to set and add

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -139,6 +139,7 @@ pub fn set_cmd(
     exclude: &[String],
     force: bool,
     adopt: bool,
+    assume_yes: bool,
 ) -> Result<(), ExitCode> {
     if let Some(invalid_groups) =
         dotfiles::check_invalid_groups(profile.clone(), dotfiles::DotfileType::Hooks, groups)
@@ -186,7 +187,7 @@ pub fn set_cmd(
                         &t!("info.symlinking_group"),
                         group.group_name.yellow().to_string().as_str(),
                     );
-                    symlinks::add_cmd(profile.clone(), groups, exclude, force, adopt)?;
+                    symlinks::add_cmd(profile.clone(), groups, exclude, force, adopt, assume_yes)?;
                 }
 
                 DeployStep::PostHook => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,10 @@ enum Command {
         /// Adopt conflicting dotfiles
         #[arg(short, long)]
         adopt: bool,
+
+        /// Automatically answer yes to stdin prompts
+        #[arg(short = 'y', long)]
+        assume_yes: bool,
     },
 
     /// Remove dotfiles for the supplied groups
@@ -86,6 +90,10 @@ enum Command {
         /// Adopt conflicting dotfiles
         #[arg(short, long)]
         adopt: bool,
+
+        /// Automatically answer yes to stdin prompts
+        #[arg(short = 'y', long)]
+        assume_yes: bool,
     },
 
     /// Encrypt files and move them to dotfiles/Secrets (alias: e)
@@ -163,14 +171,16 @@ fn main() -> ExitCode {
             exclude,
             force,
             adopt,
-        } => hooks::set_cmd(cli.profile, &groups, &exclude, force, adopt),
+            assume_yes,
+        } => hooks::set_cmd(cli.profile, &groups, &exclude, force, adopt, assume_yes),
 
         Command::Add {
             groups,
             exclude,
             force,
             adopt,
-        } => symlinks::add_cmd(cli.profile, &groups, &exclude, force, adopt),
+            assume_yes,
+        } => symlinks::add_cmd(cli.profile, &groups, &exclude, force, adopt, assume_yes),
 
         Command::Rm { groups, exclude } => symlinks::remove_cmd(cli.profile, &groups, &exclude),
         Command::Status { groups } => symlinks::status_cmd(cli.profile, groups),

--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -466,26 +466,29 @@ pub fn add_cmd(
     exclude: &[String],
     force: bool,
     adopt: bool,
+    assume_yes: bool,
 ) -> Result<(), ExitCode> {
-    if force {
-        print!("Are you sure you want to override conflicts? (N/y) ");
-    } else if adopt {
-        print!("Are you sure you want to adopt conflicts? (N/y) ");
-    }
+    if !assume_yes {
+        if force {
+            print!("Are you sure you want to override conflicts? (N/y) ");
+        } else if adopt {
+            print!("Are you sure you want to adopt conflicts? (N/y) ");
+        }
 
-    if force || adopt {
-        std::io::stdout()
-            .flush()
-            .expect("Could not print to stdout");
+        if force || adopt {
+            std::io::stdout()
+                .flush()
+                .expect("Could not print to stdout");
 
-        let mut answer = String::new();
-        std::io::stdin()
-            .read_line(&mut answer)
-            .expect("Could not read from stdin");
+            let mut answer = String::new();
+            std::io::stdin()
+                .read_line(&mut answer)
+                .expect("Could not read from stdin");
 
-        match answer.trim().to_lowercase().as_str() {
-            "y" | "yes" => (),
-            _ => return Ok(()),
+            match answer.trim().to_lowercase().as_str() {
+                "y" | "yes" => (),
+                _ => return Ok(()),
+            }
         }
     }
 
@@ -956,7 +959,7 @@ mod tests {
         );
 
         assert!(!sym.symlinked.contains_key("Group1"));
-        super::add_cmd(None, &["Group1".to_string()], &[], false, false).unwrap();
+        super::add_cmd(None, &["Group1".to_string()], &[], false, false, false).unwrap();
 
         let sym = SymlinkHandler::try_new(None).unwrap();
         assert!(sym.symlinked.contains_key("Group1"));
@@ -965,7 +968,7 @@ mod tests {
     fn test_removing_symlink() {
         let _test = Test::start();
 
-        super::add_cmd(None, &["Group1".to_string()], &[], false, false).unwrap();
+        super::add_cmd(None, &["Group1".to_string()], &[], false, false, false).unwrap();
 
         let sym = SymlinkHandler::try_new(None).unwrap();
         assert!(


### PR DESCRIPTION
Allows for scripts which use the -f option to avoid stdin prompts.

This could have been accomplished with the `yes` command on unix systems, but there's not really an equivalent on windows.