### PR TITLE
Fix err_msg in locales

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -21,7 +21,7 @@ want_to_override = "Do you want to override it? (y/N)"
 want_to_proceed = "Do you want to proceed? (y/N)"
 
 [errors]
-failed_to_symlink_x = "failed to symlink group `%{groupname}`: ${err_msg}"
+failed_to_symlink_x = "failed to symlink group `%{groupname}`: %{err_msg}"
 failed_to_link_file = "failed to link %{file}"
 no_dotfiles_for_group = "There's no dotfiles for %{group}"
 no_group = "There's no group called %{group}"

--- a/locales/es-ES.toml
+++ b/locales/es-ES.toml
@@ -21,7 +21,7 @@ want_to_override = "Quiere sustituirlos? (y/N)"
 want_to_proceed = "Quiere continuar? (y/N)"
 
 [errors]
-failed_to_symlink_x = "Ha fallado mientras estaba enlazando el grupo `%{groupname}`: ${err_msg}"
+failed_to_symlink_x = "Ha fallado mientras estaba enlazando el grupo `%{groupname}`: %{err_msg}"
 failed_to_link_file = "Ha fallado mientras estaba enlazando %{file}"
 no_dotfiles_for_group = "No existen dotfiles para %{group}"
 no_group = "No existe ningun grupo llamado %{group}"

--- a/locales/pt-PT.toml
+++ b/locales/pt-PT.toml
@@ -21,7 +21,7 @@ want_to_override = "Quer substituí-lo? (y/N)"
 want_to_proceed = "Quer continuar? (y/N)"
 
 [errors]
-failed_to_symlink_x = "Falhou a linkar o grupo `%{groupname}`: ${err_msg}"
+failed_to_symlink_x = "Falhou a linkar o grupo `%{groupname}`: %{err_msg}"
 failed_to_link_file = "falhou a linkar %{file}"
 no_dotfiles_for_group = "Não existem dotfiles para %{group}"
 no_group = "Não existe um grupo chamado %{group}"


### PR DESCRIPTION
{err_msg} was improperly prefixed with `$` instead of `%`