### PR TITLE
Add GitHub Actions workflow for mdbook deployment

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -3,6 +3,9 @@ name: Deploy mdbook to GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'book/**'
+      - '.github/workflows/mdbook.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR adds GitHub Actions workflow to build and deploy the mdbook to GitHub Pages.

Changes:
- Add GitHub Actions workflow for building the mdbook
- Configure GitHub Pages deployment
- Closes #108