### PR TITLE
Fix issues with from-stow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,7 @@ enum Command {
     GroupIs { files: Vec<String> },
 
     /// Convert a GNU Stow dotfiles repository into a Tuckr repository.
-    #[command(name = "from-stow")]
+    #[command(name = "from-stow", long_about = fileops::FROM_STOW_HELP)]
     FromStow { stow_path: Option<String> },
 }
 


### PR DESCRIPTION
for the from-stow feature:

1. from-stow wants to convert into a temporary directory but it failed because it never created the temp dir ; now it does
2. refactor help text so that it shows up when you run tuckr -h from-stow (not just when you run the command itself)
3. if dotfiles_old already exists we exit with a clear message saying this (instead of an error when we try to rename the existing dotfiles dir)
4. misc, minor adjustments to dry-run - tidying up messages, and also prevent a failure when the new, temp dotfiles dir wasn't created