### PR TITLE
Fix custom groups not being detected

### DIFF
--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -290,7 +290,7 @@ impl<'a> SymlinkHandler<'a> {
         include_invalid: bool,
     ) -> Option<Vec<String>> {
         fn __get_related_cond_groups(target_group: &str, cache: &HashCache) -> Option<Vec<String>> {
-            if dotfiles::group_target_name(target_group).is_some() {
+            if dotfiles::get_group_target(target_group).is_some() {
                 return match cache.contains_key(target_group) {
                     true => Some(vec![target_group.to_string()]),
                     false => None,


### PR DESCRIPTION
When creating two groups, `test` and `test_#custom`, and trying to add them with `tuckr add test`, the content of `test` gets symlinked but the one from the custom group doesn't.

This turned out to be a small typo in `is_valid_target`, `target.strip_prefix(target)`.

I also did a bit of refactoring to avoid splitting the target name in multiple places so it is a bit more consistent.

I identified a few more issues and areas that could be refactored but I'll open separate reports for those. As an aside, thank you for creating this tool, I have been looking for something like this for quite some time and tried other solutions that were either too complex and messy or too basic.