### PR TITLE
Follow-up fixes for #112

### DIFF
--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -675,7 +675,7 @@ pub fn from_stow_cmd(ctx: &Context, stow_path: Option<String>) -> Result<(), Exi
         println!(
             "{}",
             format!(
-                "A dotfiles_old directory already exists at `{}`\nPlease move it elsewhere or delete it before continuing",
+                "A backup directory already exists at `{}`\nPlease move it elsewhere or delete it before continuing",
                 old_dotfiles.display()
             ).red()
         );
@@ -710,8 +710,8 @@ pub fn from_stow_cmd(ctx: &Context, stow_path: Option<String>) -> Result<(), Exi
                 eprintln!("Creating directory `{}`", tuckr_path.display());
             } else {
                 fs::create_dir_all(tuckr_path).unwrap();
-                continue;
             }
+            continue;
         }
 
         if ctx.dry_run {


### PR DESCRIPTION
I saw your commit for #112.  It looks good and works well!  There's a couple small things that I'm submitting this PR for.

### I checked (and confirmed to be working):

1:   from-stow wanted to convert the stow directory into a temporary directory but it failed because it never created the temp dir ; now it does
2:   refactor help text so that it shows up when you run tuckr -h from-stow (not just when you run the command itself)

### Minor errors:

3:   if dotfiles_old already exists we exit with a clear message saying this (instead of an error when we try to rename the existing dotfiles dir)

The code is checking if the dotfiles directory (not dotfiles_old) exists and stopping at that point.  My PR fixes this so that it'll print an error only when the _old directory exists.  This means that if the dotfiles dir is there but not the _old dir then from-stow will move the current dotfiles dir into the backup _old dir

4: misc, minor adjustments to dry-run - tidying up messages, and also **prevent a failure when the new, temp dotfiles dir wasn't created** 

i didn't verify this works by running it, but looking at the code there needs to be an 'else' for `if file.is_dir() {` so that we don't try to create the dir in dry-run mode.

## New items:

5: If something goes wrong with the fs::copy(&file, &tuckr_path) operation the whole thing will halt immediately - it would be nice for this to print an error message and then keep going.  This is probably a corner case, but I encountered it when I had a broken link in my stow-files dir.  The real error is that I had a link in my stow-files dir, but having a nice error message would help folks figure that out.

6:  This is super-minor, but the code always tell the user that the old dotfiles are available in dotfiles_old, even if we didn't create an _old directory. 



One last request: could you accept my PR into the project?  I'd really like to be able to brag about "I made a commit". 
 