### PR TITLE
Fix logic error in Configs/ check

### DIFF
--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -159,7 +159,7 @@ impl<'a> SymlinkHandler<'a> {
 
         let configs_dir = self.dotfiles_dir.join("Configs");
 
-        if !configs_dir.exists() && !configs_dir.is_dir() {
+        if !configs_dir.is_dir() {
             eprintln!(
                 "{}",
                 t!(


### PR DESCRIPTION
The existing condition evaluates incorrectly to `false` if `configs_dir` exists but is not a directory. Since the documentation for `is_dir()` is

> Returns true if the path exists on disk and is pointing at a directory.

we can just remove the non-existence conjunct and get the correct behavior.