### PR TITLE
Handle file vs directory mismatches between source and target

### DIFF
--- a/src/symlinks.rs
+++ b/src/symlinks.rs
@@ -595,9 +595,9 @@ pub fn add_cmd(
                         "{}",
                         t!("dry-run.removing_x", x = deleted_file.display()).red()
                     );
-                } else if target_file.is_dir() {
+                } else if deleted_file.is_dir() {
                     fs::remove_dir_all(deleted_file).unwrap();
-                } else if target_file.is_file() {
+                } else if deleted_file.is_file() {
                     fs::remove_file(deleted_file).unwrap();
                 }
 


### PR DESCRIPTION
In the case where the target path of a source file is taken by a directory, it is currently skipped in `validate()` due to

```
if target.is_dir() {
    continue;
}
```
This seems to only be intended to catch directory-directory cases, but catches file-directory cases as well. This causes groups where all files have a directory at their target path to be missing from `tuckr status` - neither on the "Symlinked" or "Not Symlinked" side, nor shown in the "Conflicting Dotfiles" list.


A similar issue exists in `remove_files_and_decide_if_adopt()`, where the type of removal function was chosen based on the `target_file` despite running the function on `deleted_file` (which differs from `target_file` in `--adopt` cases). If there is a mismatch between source and target type, this will call the wrong function in `--adopt`.

This change fixes these behaviors by limiting the `continue` to true directory-directory cases and basing the deletion function on the type of `deleted_file` instead.