### PR TITLE
Fix --force and --adopt creating empty directories instead of symlinks

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -48,6 +48,7 @@ no_x_setup_yet = "No %{x} have been setup yet"
 not_a_tuckr_dotfile = "`%{file}` is not a tuckr dotfile."
 wrong_password = "Wrong password."
 no_configs_dir_in_dotfiles = "There is no Configs directory in dotfiles (%{dotfiles})"
+cannot_adopt_nonexistent = "Cannot adopt `%{target}`: file does not exist"
 
 # group name validation
 path_is_not_dotfiles = "`%{path}` does not belong to dotfiles"

--- a/locales/es-ES.toml
+++ b/locales/es-ES.toml
@@ -48,6 +48,7 @@ no_x_setup_yet = "Ningun %{x} ha sido configurado hasta ahora"
 not_a_tuckr_dotfile = "`%{file}` no es un fichero que pertenece a tuckr."
 wrong_password = "Contraseña incorrecta."
 no_configs_dir_in_dotfiles = "No hay un directório llamado Configs en dotfiles (%{dotfiles})"
+cannot_adopt_nonexistent = "No se puede adoptar `%{target}`: el archivo no existe"
 
 # group name validation
 path_is_not_dotfiles = "`%{path}` no pertenece a los dotfiles"

--- a/locales/pt-PT.toml
+++ b/locales/pt-PT.toml
@@ -47,6 +47,8 @@ no_dir_setup_for_x = "Não há um diretório criado para %{x}"
 no_x_setup_yet = "Ainda nenhum %{x} foi configurado"
 not_a_tuckr_dotfile = "`%{file}` não é um ficheiro do tuckr."
 wrong_password = "Palavra-passe errada."
+no_configs_dir_in_dotfiles = "Não existe um diretório Configs nos dotfiles (%{dotfiles})"
+cannot_adopt_nonexistent = "Não é possível adotar `%{target}`: o ficheiro não existe"
 
 # group name validation
 path_is_not_dotfiles = "`%{path}` não pertence aos dotfiles"


### PR DESCRIPTION
## Summary

Fixes #127 - `--force` and `--adopt` options exhibit destructive behavior that creates empty directories instead of symlinks.

## Changes

### 1. Fix symlink/file removal in `remove_files_and_decide_if_adopt()`

**Before:** The removal logic only handled `is_dir()` and `is_file()`, missing symlinks that don't resolve:
```rust
} else if target_file.is_dir() {
    fs::remove_dir_all(deleted_file).unwrap();
} else if target_file.is_file() {
    fs::remove_file(deleted_file).unwrap();
}
```

**After:** Uses `exists() || is_symlink()` to properly handle all file types including broken symlinks.

### 2. Fix --adopt deleting source when target doesn't exist

**Before:** The source file in the dotfiles repo was deleted unconditionally before checking if the target existed.

**After:** Now checks if target exists before deleting source, with a warning message if adopt is not possible.

### 3. Fix directory creation in `SymlinkHandler::add()`

**Before:** After removing a file, `target_path.is_file()` returns false, causing `create_dir_all(&target_path)` to create the target as a directory:
```rust
fs::create_dir_all(if target_path.is_file() {
    target_path.parent().unwrap()
} else {
    &target_path  // BUG: creates target as directory!
})
```

**After:** Always uses `.parent()` to only create parent directories.

## Testing

- `cargo check` passes
- `cargo test` passes (except for pre-existing unrelated failure in `ignore_garbage_files`)
- The `add_and_remove_symlink` test passes

## Impact

These bugs caused 185+ files to become empty directories when using `--force`, affecting SSH keys, shell configs, fonts, and other critical dotfiles.